### PR TITLE
corrected link usage

### DIFF
--- a/challenge.md
+++ b/challenge.md
@@ -32,4 +32,4 @@ accomplish:
 
 At the end of January we will post a link to our account in the appstore where
 you can find all our released apps. In the meantime checkout our
-[GitHub account]({{ site.github }}) to see our current progess.
+[GitHub account]({{ site.contact.github }}) to see our current progess.


### PR DESCRIPTION
Was: `{{site.github}}` which returns a lot of info regarding the github user, but not the one we want.

Is: `{{site.contact.github}}`, a link used in other places too, which is set up manually.

Thoughts: the github is also possible through `{{site.github.html_url}}` IIRC. For that you'll need the gem: `jekyll-github-metadata`.
This will work without configuration on the github server, but to check locally you'll need the gem. I think the first solution feels easier because there's no need to check if the name or url changed on every build.